### PR TITLE
Response headers in exception

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 init:
   # Good practise, because Windows line endings are different from Unix/Linux ones
   - cmd: git config --global core.autocrlf true
+  - cmd: set PATH=C:\Program Files (x86)\MSBuild\15.0\Bin;%PATH%
 install:
   # Install repo specific stuff here
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '1.0.{build}'
 configuration: Debug
-image: Visual Studio 2017
+image: Visual Studio 2019
 branches:
   only:
   - master

--- a/src/GraphQl.NetStandard.Client/GraphQLClient.cs
+++ b/src/GraphQl.NetStandard.Client/GraphQLClient.cs
@@ -128,12 +128,12 @@ namespace GraphQl.NetStandard.Client
                         errorMessages.Add(errorJObject["message"].Value<string>());
                     }
 
-                    throw new GraphQLQueryException(errorMessages);
+                    throw new GraphQLQueryException(errorMessages, httpResponseMessage.Headers);
                 }
             }
             else if (!httpResponseMessage.IsSuccessStatusCode)
             {
-                throw new GraphQLRequestException(httpResponseMessage.StatusCode, responseContent);
+                throw new GraphQLRequestException(httpResponseMessage.StatusCode, responseContent, httpResponseMessage.Headers);
             }
         }
     }

--- a/src/GraphQl.NetStandard.Client/GraphQLRequestException.cs
+++ b/src/GraphQl.NetStandard.Client/GraphQLRequestException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace GraphQl.NetStandard.Client
 {
@@ -10,6 +12,7 @@ namespace GraphQl.NetStandard.Client
     {
         public HttpStatusCode HttpStatusCode { get; set; }
         public string ResponseBody { get; set; }
+        public HttpResponseHeaders ResponseHeaders { get; set; }
 
         public override string Message
         {
@@ -21,10 +24,11 @@ namespace GraphQl.NetStandard.Client
 
         private GraphQLRequestException() { }
 
-        public GraphQLRequestException(HttpStatusCode httpStatusCode, string responseBody) : base()
+        public GraphQLRequestException(HttpStatusCode httpStatusCode, string responseBody, HttpResponseHeaders httpResponseHeaders) : base()
         {
             HttpStatusCode = httpStatusCode;
             ResponseBody = responseBody;
+            ResponseHeaders = httpResponseHeaders;
         }
     }
 }

--- a/src/GraphQl.NetStandard.Client/GraphQl.NetStandard.Client.csproj
+++ b/src/GraphQl.NetStandard.Client/GraphQl.NetStandard.Client.csproj
@@ -9,10 +9,10 @@
     <Description>A simple and testable GraphQL client for .NET and .NET core</Description>
     <RepositoryUrl>https://github.com/Firenza/graphql-netstandard-client</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <PackageProjectUrl>https://github.com/Firenza/graphql-netstandard-client</PackageProjectUrl>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
+    <FileVersion>2.4.0.0</FileVersion>
     <!--Include PDBs in the NuGet package so uploading a seperate symbols package is not needed-->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/src/GraphQl.NetStandard.Client/GraphQlQueryException.cs
+++ b/src/GraphQl.NetStandard.Client/GraphQlQueryException.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Headers;
 
 namespace GraphQl.NetStandard.Client
 {
@@ -10,6 +11,8 @@ namespace GraphQl.NetStandard.Client
     public class GraphQLQueryException : Exception
     {
         public List<string> ErrorMessages { get; set; }
+        public HttpResponseHeaders ResponseHeaders { get; set; }
+
 
         public override string Message
         {
@@ -28,9 +31,10 @@ namespace GraphQl.NetStandard.Client
 
         private GraphQLQueryException() { }
 
-        public GraphQLQueryException(IEnumerable<string> errorMessages) : base()
+        public GraphQLQueryException(IEnumerable<string> errorMessages, HttpResponseHeaders httpResponseHeaders) : base()
         {
             ErrorMessages = errorMessages.ToList();
+            ResponseHeaders = httpResponseHeaders;
         }
     }
 }


### PR DESCRIPTION
For requests that fail due to rate limiting, it's helpful for the client to know how long they have to wait until they can try again so when throwing an exception include the HTTP response headers